### PR TITLE
Changing $query to array

### DIFF
--- a/statsvisits.php
+++ b/statsvisits.php
@@ -31,7 +31,7 @@ if (!defined('_PS_VERSION_')) {
 class statsvisits extends ModuleGraph
 {
     private $html = '';
-    private $query = '';
+    private $query = [];
 
     public function __construct()
     {


### PR DESCRIPTION
Changing query variable from string to array to produce the correct results for visits and visitors