### PR TITLE
Update statsvisits.php

### DIFF
--- a/statsvisits.php
+++ b/statsvisits.php
@@ -31,7 +31,7 @@ if (!defined('_PS_VERSION_')) {
 class statsvisits extends ModuleGraph
 {
     private $html = '';
-    private $query = '';
+    private $query = [];
 
     public function __construct()
     {


### PR DESCRIPTION
Wrong $query init.

$query is an array


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | the variable $query is an array not a string
| Type?         | bug fix
| BC breaks?    | yes 
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | add the fix and you will see the graphics appear in the statistic backoffice Visits and Visitors

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
